### PR TITLE
Unit planning form layout

### DIFF
--- a/components/common/input.js
+++ b/components/common/input.js
@@ -17,13 +17,25 @@ export default function Input({
   readonly,
   labelClass,
   inputClass,
+  gray,
+  full,
+  placeholder,
 }) {
   const inputClasses = cx(
-    "mt-1 block w-full rounded-md bg-gray-100 border-transparent focus:border-gray-500 focus:bg-white focus:ring-0",
+    "mt-1 block rounded-md border-transparent focus:ring-0",
+    {
+      "w-full": full,
+      "bg-gray-100 focus:border-gray-500 focus:bg-white": gray,
+      "text-black": !gray,
+    },
     inputClass
   );
   const labelClassNames = cx("block", labelClass);
-  const inputId = `${addUnderscoresToString(label)}${generateRandomId()}`;
+  const labelSpanClassNames = cx("uppercase font-light", {
+    "text-white": gray,
+  });
+  const inputId =
+    label && `${addUnderscoresToString(label)}${generateRandomId()}`;
 
   return (
     <>
@@ -31,7 +43,7 @@ export default function Input({
         htmlFor={addUnderscoresToString(label)}
         className={labelClassNames}
       >
-        <span className="uppercase text-white font-light">{label}</span>
+        {label && <span className={labelSpanClassNames}>{label}</span>}
         {type === TYPES.text && (
           <input
             id={inputId}
@@ -65,6 +77,7 @@ export default function Input({
             onChange={onChange}
             required={required}
             readOnly={readonly}
+            placeholder={placeholder}
           />
         )}
       </label>
@@ -73,7 +86,7 @@ export default function Input({
 }
 
 Input.propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   type: PropTypes.oneOf(Object.values(TYPES)).isRequired,
   onChange: PropTypes.func,
   required: PropTypes.bool,
@@ -81,4 +94,6 @@ Input.propTypes = {
   readonly: PropTypes.bool,
   labelClass: PropTypes.string,
   inputClass: PropTypes.string,
+  full: PropTypes.bool,
+  gray: PropTypes.bool,
 };

--- a/components/layout.js
+++ b/components/layout.js
@@ -1,4 +1,4 @@
-import Head from 'next/head';
+import Head from "next/head";
 
 export default function Layout({ children }) {
   return (
@@ -8,11 +8,11 @@ export default function Layout({ children }) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <nav className="p-4 bg-blue text-white uppercase text-xl tracking-wider">
+      <nav className="p-4 bg-blue text-white uppercase text-xl tracking-wider sticky top-0">
         Teacher Lab
       </nav>
       <main>{children}</main>
       {/* <footer>footer</footer> */}
     </>
-  )
+  );
 }

--- a/components/unit/unit-card-form.js
+++ b/components/unit/unit-card-form.js
@@ -44,6 +44,8 @@ export default function UnitCardForm({
         value={unitNumber}
         type="number"
         label="unit number"
+        gray
+        full
         required
       ></Input>
       <Input
@@ -51,6 +53,8 @@ export default function UnitCardForm({
         value={unitTitle}
         type="text"
         label="unit title"
+        gray
+        full
         required
       ></Input>
       <Input
@@ -58,6 +62,8 @@ export default function UnitCardForm({
         value={startDate}
         type="date"
         label="start date"
+        gray
+        full
         required
       ></Input>
       <Input
@@ -65,6 +71,8 @@ export default function UnitCardForm({
         value={endDate}
         type="date"
         label="end date"
+        gray
+        full
         required
       ></Input>
       <Input
@@ -72,6 +80,8 @@ export default function UnitCardForm({
         value={reviewDate}
         type="date"
         label="review date"
+        gray
+        full
         required
       ></Input>
       <div className="flex justify-around">

--- a/components/unit/unit-card.js
+++ b/components/unit/unit-card.js
@@ -24,7 +24,9 @@ export default function UnitCard({ unit, subjectName }) {
         type="text"
         label="unit duration"
         value={unitDuration}
+        gray
         readonly
+        full
       />
       <Input
         inputClass="text-center text-lg font-light tracking-wide p-1"
@@ -33,7 +35,9 @@ export default function UnitCard({ unit, subjectName }) {
         type="text"
         label="final review"
         value={reviewDate}
+        gray
         readonly
+        full
       />
     </div>
   );

--- a/components/unit/unit-form-nav.js
+++ b/components/unit/unit-form-nav.js
@@ -1,0 +1,28 @@
+import PropTypes from "prop-types";
+
+export default function UnitFormNav({ unit }) {
+  return (
+    <div className="bg-blue p-7 pt-4 mt-14 sticky" style={{ top: "117px" }}>
+      <div className="flex flex-col justify-between items-center text-white">
+        <div className="rounded-full bg-yellow-500 w-24 h-24 text-4xl font-light flex justify-center self-center">
+          <div className="self-center text-black">U{unit.number}</div>
+        </div>
+        <div className="font-semibold text-lg mt-4">ELA</div>
+        <div className="mt-2 mb-4 tracking-wider font-light">{unit.title}</div>
+
+        <div className="border-t w-full text-center">
+          <div className="font-light text-lg mb-2 mt-4">link 1</div>
+          <div className="font-light text-lg mb-2">link 2</div>
+          <div className="font-light text-lg mb-2">link 3</div>
+          <div className="font-light text-lg mb-2">link 4</div>
+          <div className="font-light text-lg mb-2">link 5</div>
+          <div className="font-light text-lg mb-2">link 6</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+UnitFormNav.propTypes = {
+  unit: PropTypes.object.isRequired,
+}

--- a/libs/utils.js
+++ b/libs/utils.js
@@ -1,4 +1,6 @@
 export const addUnderscoresToString = function (str) {
+  if (!str) return;
+
   const strArr = str.split(" ");
 
   if (strArr.length <= 1) return str;

--- a/pages/units/[id].js
+++ b/pages/units/[id].js
@@ -1,0 +1,49 @@
+import UnitFormNav from "../../components/unit/unit-form-nav";
+import Input from "../../components/common/input";
+import { getUnit } from "../../services/unit";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+export default function UnitForm() {
+  const router = useRouter();
+  const [unit, setUnit] = useState();
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    const { id } = router.query;
+
+    try {
+      getUnit(id).then((unitData) => {
+        setUnit(unitData);
+      });
+    } catch (e) {
+      console.log(e);
+    }
+  }, [router.isReady]);
+
+  return (
+    <div className="grid grid-cols-12">
+      <div className="col-span-4 w-3/5 mx-auto relative">
+        {unit && <UnitFormNav unit={unit}></UnitFormNav>}
+      </div>
+      <div className="col-span-7 col-start-5 mt-14">
+        <div className="flex flex-col space-y-4">
+          <div className="py-3 bg-gray-200 flex items-center justify-around">
+            <Input label="start date" type="date" />
+            <Input label="end date" type="date" />
+            <Input label="review date" type="date" />
+          </div>
+          <div className="h-16 bg-gray-200 text-white flex items-center justify-center text-2xl font-extrabold">
+            2
+          </div>
+          <div className="h-16 bg-gray-200 text-white flex items-center justify-center text-2xl font-extrabold">
+            3
+          </div>
+          <div className="h-16 bg-gray-200 text-white flex items-center justify-center text-2xl font-extrabold">
+            1
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/services/unit.js
+++ b/services/unit.js
@@ -1,8 +1,14 @@
 import { protectedFetcher } from "./utils";
 
 export const createUnit = function (data) {
-  return protectedFetcher(`/units`, {
+  return protectedFetcher("/units", {
     method: "POST",
     body: JSON.stringify(data),
   });
 };
+
+export const getUnit = function(unitId) {
+  return protectedFetcher(`/units/${unitId}`, {
+    method: "GET"
+  });
+}


### PR DESCRIPTION
This adds an initial layout for the unit form, it does not have a working Nav currently.  That will be done in future iterations, most likely last after the form is complete.  I'm also going to break down the layout further into separate components, but leaving this as the initial layout commit before I move further.

- add new dynamic page [id].js for units
- adds getUnit service fetch function
- update input to support customizable props
- add UnitFormNav

<img width="1260" alt="Screen Shot 2021-04-04 at 8 37 57 PM" src="https://user-images.githubusercontent.com/5693674/113534454-a7014780-9585-11eb-9c80-8d5bdea94dea.png">
