### PR TITLE
Add redux-toolkit and initial slicer

### DIFF
--- a/components/common/input.js
+++ b/components/common/input.js
@@ -34,15 +34,11 @@ export default function Input({
   const labelSpanClassNames = cx("uppercase font-light", {
     "text-white": gray,
   });
-  const inputId =
-    label && `${addUnderscoresToString(label)}${generateRandomId()}`;
+  const inputId = label && addUnderscoresToString(label);
 
   return (
     <>
-      <label
-        htmlFor={addUnderscoresToString(label)}
-        className={labelClassNames}
-      >
+      <label htmlFor={inputId} className={labelClassNames}>
         {label && <span className={labelSpanClassNames}>{label}</span>}
         {type === TYPES.text && (
           <input

--- a/components/unit/unit-form-section.js
+++ b/components/unit/unit-form-section.js
@@ -1,0 +1,7 @@
+export default function UnitFormSection({ children }) {
+  return (
+    <div className="py-3 bg-gray-200 flex items-center justify-around">
+      {children}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.5.1",
     "@tailwindcss/forms": "^0.3.2",
     "classnames": "^2.3.0",
     "date-fns": "^2.19.0",
@@ -16,6 +17,7 @@
     "prop-types": "^15.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-redux": "^7.2.3",
     "swr": "^0.5.4"
   },
   "devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,24 +3,28 @@ import "tailwindcss/tailwind.css";
 import UserContext from "../components/context/user-context";
 import Layout from "../components/layout";
 import storage from "../libs/storage";
+import store from "../store/index";
 import { isAuthenticated, getLoggedInUser } from "../services/auth";
+import { Provider } from "react-redux";
 import { useState, useEffect } from "react";
 
 function MyApp({ Component, pageProps }) {
   const [user, setUser] = useState({});
 
   useEffect(() => {
-    if(isAuthenticated()) {
+    if (isAuthenticated()) {
       setUser(getLoggedInUser());
     }
   }, []);
 
   return (
-    <UserContext.Provider value={{ user, setUser }}>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
-    </UserContext.Provider>
+    <Provider store={store}>
+      <UserContext.Provider value={{ user, setUser }}>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </UserContext.Provider>
+    </Provider>
   );
 }
 

--- a/pages/units/[id].js
+++ b/pages/units/[id].js
@@ -1,12 +1,29 @@
 import UnitFormNav from "../../components/unit/unit-form-nav";
+import UnitFormSection from "../../components/unit/unit-form-section";
+import UnitFormDates from "../../components/unit/unit-form-dates";
 import Input from "../../components/common/input";
+import { useSelector, useDispatch } from "react-redux";
+import {
+  setStartDate,
+  setEndDate,
+  setReviewDate,
+  setUnit,
+  selectUnit,
+  selectStartDate,
+  selectEndDate,
+  selectReviewDate,
+} from "../../store/unitSlicer";
 import { getUnit } from "../../services/unit";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 export default function UnitForm() {
+  const unit = useSelector(selectUnit);
+  const startDate = useSelector(selectStartDate);
+  const endDate = useSelector(selectEndDate);
+  const reviewDate = useSelector(selectReviewDate);
+  const dispatch = useDispatch();
   const router = useRouter();
-  const [unit, setUnit] = useState();
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -14,7 +31,7 @@ export default function UnitForm() {
 
     try {
       getUnit(id).then((unitData) => {
-        setUnit(unitData);
+        dispatch(setUnit(unitData));
       });
     } catch (e) {
       console.log(e);
@@ -28,11 +45,26 @@ export default function UnitForm() {
       </div>
       <div className="col-span-7 col-start-5 mt-14">
         <div className="flex flex-col space-y-4">
-          <div className="py-3 bg-gray-200 flex items-center justify-around">
-            <Input label="start date" type="date" />
-            <Input label="end date" type="date" />
-            <Input label="review date" type="date" />
-          </div>
+          <UnitFormSection>
+            <Input
+              label="start date"
+              type="date"
+              value={startDate}
+              onChange={(event) => dispatch(setStartDate(event.target.value))}
+            />
+            <Input
+              label="end date"
+              type="date"
+              value={endDate}
+              onChange={(event) => dispatch(setEndDate(event.target.value))}
+            />
+            <Input
+              label="review date"
+              type="date"
+              value={reviewDate}
+              onChange={(event) => dispatch(setReviewDate(event.target.value))}
+            />
+          </UnitFormSection>
           <div className="h-16 bg-gray-200 text-white flex items-center justify-center text-2xl font-extrabold">
             2
           </div>

--- a/pages/units/[id].js
+++ b/pages/units/[id].js
@@ -1,6 +1,5 @@
 import UnitFormNav from "../../components/unit/unit-form-nav";
 import UnitFormSection from "../../components/unit/unit-form-section";
-import UnitFormDates from "../../components/unit/unit-form-dates";
 import Input from "../../components/common/input";
 import { useSelector, useDispatch } from "react-redux";
 import {

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,8 @@
+import { configureStore } from '@reduxjs/toolkit';
+import unitReducer from "../store/unitSlicer";
+
+export default configureStore({
+  reducer: {
+    unit: unitReducer,
+  },
+});

--- a/store/unitSlicer.js
+++ b/store/unitSlicer.js
@@ -1,0 +1,51 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export const unitSlice = createSlice({
+  name: "unit",
+  initialState: {
+    completed: false,
+    details: null,
+    id: null,
+    number: null,
+    reviewDate: "",
+    startDate: "",
+    endDate: "",
+    subjectId: null,
+    title: "",
+  },
+  reducers: {
+    setStartDate: (state, action) => {
+      state.startDate = action.payload;
+    },
+
+    setEndDate: (state, action) => {
+      state.startDate = action.payload;
+    },
+
+    setReviewDate: (state, action) => {
+      state.reviewDate = action.payload;
+    },
+
+    setUnit: (state, action) => {
+      state.startDate = action.payload.startDate;
+      state.endDate = action.payload.endDate;
+      state.reviewDate = action.payload.reviewDate;
+      state.number = action.payload.number;
+      state.title = action.payload.title;
+    },
+  },
+});
+
+export const {
+  setStartDate,
+  setEndDate,
+  setReviewDate,
+  setUnit,
+} = unitSlice.actions;
+
+export const selectUnit = (state) => state.unit;
+export const selectStartDate = (state) => state.unit.startDate;
+export const selectEndDate = (state) => state.unit.endDate;
+export const selectReviewDate = (state) => state.unit.reviewDate;
+
+export default unitSlice.reducer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.1":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/types@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
@@ -110,12 +117,59 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
   integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
 
+"@reduxjs/toolkit@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.5.1.tgz#05daa2f6eebc70dc18cd98a90421fab7fa565dc5"
+  integrity sha512-PngZKuwVZsd+mimnmhiOQzoD0FiMjqVks6ituO1//Ft5UEX5Ca9of13NEjo//pU22Jk7z/mdXVsmDfgsig1osA==
+  dependencies:
+    immer "^8.0.1"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@tailwindcss/forms@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.3.2.tgz#e28c4514a53e69f725416a5a2a6d0f221683f069"
   integrity sha512-aj2/rJsGb2whAZ/BQWHWWQRSbhH0r/l1ozOByiv+ZNjBD84GMvb5dhAyfpeasFky+EJrAwX5eaqft8NQMZFWvA==
   dependencies:
     mini-svg-data-uri "^1.2.3"
+
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react-redux@^7.1.16":
+  version "7.1.16"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.16.tgz#0fbd04c2500c12105494c83d4a3e45c084e3cb21"
+  integrity sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
+"@types/react@*":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
+  integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
 acorn-node@^1.6.1:
   version "1.8.2"
@@ -607,6 +661,11 @@ cssnano-simple@1.2.2:
     cssnano-preset-simple "1.2.2"
     postcss "^7.0.32"
 
+csstype@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
+  integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==
+
 data-uri-to-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
@@ -864,6 +923,13 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 html-tags@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
@@ -896,6 +962,11 @@ ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
+immer@^8.0.1:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.4.tgz#3a21605a4e2dded852fb2afd208ad50969737b7a"
+  integrity sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ==
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -1553,10 +1624,22 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-is@16.13.1, react-is@^16.8.1:
+react-is@16.13.1, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-redux@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.3.tgz#4c084618600bb199012687da9e42123cca3f0be9"
+  integrity sha512-ZhAmQ1lrK+Pyi0ZXNMUZuYxYAZd59wFuVDGUt536kSGdD0ya9Q7BfsE95E3TsFLE3kOSFp5m6G5qbatE+Ic1+w==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    "@types/react-redux" "^7.1.16"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.13.1"
 
 react-refresh@0.8.3:
   version "0.8.3"
@@ -1608,10 +1691,28 @@ reduce-css-calc@^2.1.8:
     css-unit-converter "^1.1.1"
     postcss-value-parser "^3.3.0"
 
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
+redux@^4.0.0:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
+
 regenerator-runtime@^0.13.4:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resolve@^1.20.0:
   version "1.20.0"
@@ -1825,6 +1926,11 @@ swr@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/swr/-/swr-0.5.4.tgz#9516af6ffd84ba2c23a804ff771be2eb83ba8d46"
   integrity sha512-TUSxxuC8uP/4JKV22ml91WQ0tbif+9HVhm683xm8KYfwZIW5ogwcnU634dg3x6N7azpIDIOLokoIi+z5vCz/yA==
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 tailwindcss@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
No visual changes from the previous PR.  I wanted to include redux at this point because I want to break down the from sections into separate components and the amount of state to handle at the parent level would be rather complex.  The New approach is for redux to handle the form data and this will allow me to separate the form into independent pieces not tied to the parent form container.

- adds unitSlice with initiaState and reducers
- adds redux store Provider to app
- setup unit form to use unit store
- Adds UnitFormSection for reusable style wrapper
- updates input to make inputId only show when label exists