### PR TITLE
Add visibility constraints for sidebar and redirects to login when user not authenticated

### DIFF
--- a/components/dashboard/dashboard-column.js
+++ b/components/dashboard/dashboard-column.js
@@ -24,6 +24,7 @@ export default function DashboardColumn({ user, subject, subjectName }) {
             subject={subject}
             closeAction={toggleUnitCard.bind({}, false)}
             showUnitCard={subjectHasUnit}
+            user={user}
           ></UnitCardContainer>
         ) : (
           <>

--- a/components/dashboard/dashboard.js
+++ b/components/dashboard/dashboard.js
@@ -1,11 +1,12 @@
 import DashboardColumn from "./dashboard-column";
 import PropTypes from "prop-types";
-import { isAuthenticated } from "../../services/auth";
 import { getSubjects } from "../../services/user";
+import { useSelector } from "react-redux";
 import { SUBJECTS } from "../../libs/constants";
 import { useEffect, useState } from "react";
 
 export default function Dashboard({ user }) {
+  const isAuthenticated = useSelector((state) => state.user.isAuthenticated);
   const [subjectsByGrade, setSubjectsByGrade] = useState([]);
   const [selectedGrade] = useState("5");
 
@@ -23,7 +24,7 @@ export default function Dashboard({ user }) {
   }
 
   useEffect(async () => {
-    if (!isAuthenticated()) {
+    if (!isAuthenticated) {
       return;
     }
 
@@ -33,7 +34,7 @@ export default function Dashboard({ user }) {
 
   return (
     <>
-      {isAuthenticated() && (
+      {isAuthenticated && (
         <div className="grid grid-flow-col grid-cols-3 divide-x min-h-screen -mt-16 pt-16">
           <DashboardColumn
             subject={getSubjectData(SUBJECTS.ela)}

--- a/components/dashboard/dashboard.js
+++ b/components/dashboard/dashboard.js
@@ -1,13 +1,13 @@
 import DashboardColumn from "./dashboard-column";
 import PropTypes from "prop-types";
+import { isAuthenticated } from "../../services/auth";
 import { getSubjects } from "../../services/user";
 import { SUBJECTS } from "../../libs/constants";
 import { useEffect, useState } from "react";
 
 export default function Dashboard({ user }) {
   const [subjectsByGrade, setSubjectsByGrade] = useState([]);
-  const [allSubjects, setAllSubjects] = useState([]);
-  const [selectedGrade, setSelectedGrade] = useState("5");
+  const [selectedGrade] = useState("5");
 
   function getSubjectsByGrade(allSubjects) {
     const subjects = allSubjects.filter(
@@ -23,34 +23,39 @@ export default function Dashboard({ user }) {
   }
 
   useEffect(async () => {
+    if (!isAuthenticated()) {
+      return;
+    }
+
     const res = await getSubjects();
-    setAllSubjects(res);
     setSubjectsByGrade(getSubjectsByGrade(res));
   }, []);
 
   return (
     <>
-      <div className="grid grid-flow-col grid-cols-3 divide-x min-h-screen -mt-16 pt-16">
-        <DashboardColumn
-          subject={getSubjectData(SUBJECTS.ela)}
-          subjectName={SUBJECTS.ela}
-          user={user}
-        ></DashboardColumn>
-        <DashboardColumn
-          subject={getSubjectData(SUBJECTS.math)}
-          subjectName={SUBJECTS.math}
-          user={user}
-        ></DashboardColumn>
-        <DashboardColumn
-          subject={getSubjectData(SUBJECTS.science)}
-          subjectName={SUBJECTS.science}
-          user={user}
-        ></DashboardColumn>
-      </div>
+      {isAuthenticated() && (
+        <div className="grid grid-flow-col grid-cols-3 divide-x min-h-screen -mt-16 pt-16">
+          <DashboardColumn
+            subject={getSubjectData(SUBJECTS.ela)}
+            subjectName={SUBJECTS.ela}
+            user={user}
+          ></DashboardColumn>
+          <DashboardColumn
+            subject={getSubjectData(SUBJECTS.math)}
+            subjectName={SUBJECTS.math}
+            user={user}
+          ></DashboardColumn>
+          <DashboardColumn
+            subject={getSubjectData(SUBJECTS.science)}
+            subjectName={SUBJECTS.science}
+            user={user}
+          ></DashboardColumn>
+        </div>
+      )}
     </>
   );
 }
 
 Dashboard.propTypes = {
-  user: PropTypes.object
-}
+  user: PropTypes.object,
+};

--- a/components/layout/sidebar.js
+++ b/components/layout/sidebar.js
@@ -1,4 +1,6 @@
 import { logout } from "../../services/auth";
+import { setIsAuthenticated } from "../../store/user-slicer";
+import { useDispatch } from "react-redux";
 import { useRouter } from "next/router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -16,6 +18,7 @@ import { useState } from "react";
 import cx from "classnames";
 
 export default function SideBar() {
+  const dispatch = useDispatch();
   const router = useRouter();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const titleClasses = cx(
@@ -30,6 +33,7 @@ export default function SideBar() {
 
   function handleLogout() {
     logout();
+    dispatch(setIsAuthenticated(false));
     router.push("/login");
   }
 

--- a/components/layout/sidebar.js
+++ b/components/layout/sidebar.js
@@ -1,3 +1,5 @@
+import { logout } from "../../services/auth";
+import { useRouter } from "next/router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   ProSidebar,
@@ -5,6 +7,8 @@ import {
   MenuItem,
   SubMenu,
   SidebarHeader,
+  SidebarContent,
+  SidebarFooter,
 } from "react-pro-sidebar";
 import { faGem, faHeart } from "@fortawesome/free-regular-svg-icons";
 import { faChevronLeft, faBars } from "@fortawesome/free-solid-svg-icons";
@@ -12,6 +16,7 @@ import { useState } from "react";
 import cx from "classnames";
 
 export default function SideBar() {
+  const router = useRouter();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const titleClasses = cx(
     "uppercase text-yellow text-x transition duration-200 ease-in-out self-center",
@@ -19,6 +24,14 @@ export default function SideBar() {
       "transform-gpu -translate-x-44 absolute -left-16": isCollapsed,
     }
   );
+  const footerClasses = cx("p-3 text-center uppercase", {
+    "transform-gpu -translate-x-44 absolute -left-16": isCollapsed,
+  });
+
+  function handleLogout() {
+    logout();
+    router.push("/login");
+  }
 
   return (
     <ProSidebar
@@ -48,24 +61,35 @@ export default function SideBar() {
           )}
         </div>
       </SidebarHeader>
-      <Menu
-        iconShape="circle"
-        className="border-t-2 border-white bg-blue"
-        popperArrow
-      >
-        <MenuItem
-          icon={<FontAwesomeIcon icon={faGem} className="cursor-pointer" />}
+      <SidebarContent>
+        <Menu
+          iconShape="circle"
+          className="border-t-2 border-white bg-blue"
+          popperArrow
         >
-          Dashboard
-        </MenuItem>
-        <SubMenu
-          title="Components"
-          icon={<FontAwesomeIcon icon={faHeart} className="cursor-pointer" />}
+          <MenuItem
+            icon={<FontAwesomeIcon icon={faGem} className="cursor-pointer" />}
+          >
+            Dashboard
+          </MenuItem>
+          <SubMenu
+            title="Components"
+            icon={<FontAwesomeIcon icon={faHeart} className="cursor-pointer" />}
+          >
+            <MenuItem>Component 1</MenuItem>
+            <MenuItem>Component 2</MenuItem>
+          </SubMenu>
+        </Menu>
+      </SidebarContent>
+      <SidebarFooter>
+        <div
+          className={footerClasses}
+          role="button"
+          onClick={() => handleLogout()}
         >
-          <MenuItem>Component 1</MenuItem>
-          <MenuItem>Component 2</MenuItem>
-        </SubMenu>
-      </Menu>
+          Logout
+        </div>
+      </SidebarFooter>
     </ProSidebar>
   );
 }

--- a/components/layout/wrapper.js
+++ b/components/layout/wrapper.js
@@ -1,8 +1,19 @@
+import { isAuthenticated } from "../../services/auth";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 import SideNav from "./sidebar";
 import Nav from "./nav";
 import Head from "next/head";
 
 export default function Wrapper({ children }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isAuthenticated()) {
+      router.push("/login");
+    }
+  }, []);
+
   return (
     <>
       <Head>
@@ -12,7 +23,7 @@ export default function Wrapper({ children }) {
 
       <div className="h-screen">
         <div className="flex h-full">
-          <SideNav />
+          {isAuthenticated() && <SideNav />}
           <div className="w-full flex flex-col">
             <div>
               <Nav />

--- a/components/layout/wrapper.js
+++ b/components/layout/wrapper.js
@@ -1,17 +1,25 @@
 import { isAuthenticated } from "../../services/auth";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { setIsAuthenticated } from "../../store/user-slicer";
 import SideNav from "./sidebar";
 import Nav from "./nav";
 import Head from "next/head";
 
 export default function Wrapper({ children }) {
+  const isUserAuthenticated = useSelector(
+    (state) => state.user.isAuthenticated
+  );
+  const dispatch = useDispatch();
   const router = useRouter();
 
   useEffect(() => {
     if (!isAuthenticated()) {
       router.push("/login");
     }
+
+    dispatch(setIsAuthenticated(isAuthenticated()));
   }, []);
 
   return (
@@ -23,7 +31,7 @@ export default function Wrapper({ children }) {
 
       <div className="h-screen">
         <div className="flex h-full">
-          {isAuthenticated() && <SideNav />}
+          {isUserAuthenticated && <SideNav />}
           <div className="w-full flex flex-col">
             <div>
               <Nav />

--- a/components/unit/assessment-table-row.js
+++ b/components/unit/assessment-table-row.js
@@ -116,10 +116,10 @@ export default function AssessmentTableRow({
                 index,
               })
             }
-            value={assessment.proficiency}
+            value={assessment.proficient}
           />
         ) : (
-          appendPercentage(assessment.proficiency)
+          appendPercentage(assessment.proficient)
         )}
       </td>
       <td className="border border-black px-4 py-2 text-center">

--- a/components/unit/unit-card-container.js
+++ b/components/unit/unit-card-container.js
@@ -3,17 +3,25 @@ import UnitCard from "./unit-card";
 import PropTypes from "prop-types";
 import { UNIT_FORM_DATA_SYMBOLS } from "../../libs/constants";
 import { useState } from "react";
+import { useRouter } from "next/router";
+import cx from "classnames";
 
 export default function UnitCardContainer({
   closeAction,
   subject,
   showUnitCard,
+  user,
 }) {
+  const router = useRouter();
   const [unitNumber, setUnitNumber] = useState("1");
   const [unitTitle, setUnitTitle] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [reviewDate, setReviewDate] = useState("");
+  const firstUnit = subject.units[0];
+  const unitCardClasses = cx("bg-blue w-72 mx-auto p-7 pt-4", {
+    "cursor-pointer": !user.admin,
+  });
 
   function handleUnitFormDataChange(inputSymbol, event) {
     const value = event.target.value;
@@ -43,10 +51,17 @@ export default function UnitCardContainer({
     closeAction();
   }
 
+  function navigateToUnit(unitId) {
+    router.push(`/units/${unitId}`);
+  }
+
   return (
-    <div className="bg-blue w-72 mx-auto p-7 pt-4">
+    <div
+      className={unitCardClasses}
+      onClick={() => navigateToUnit(firstUnit?.id)}
+    >
       {showUnitCard ? (
-        <UnitCard unit={subject.units[0]} subjectName={subject.name}></UnitCard>
+        <UnitCard unit={firstUnit} subjectName={subject.name}></UnitCard>
       ) : (
         <UnitCardForm
           onChange={handleUnitFormDataChange}
@@ -68,4 +83,5 @@ UnitCardContainer.propTypes = {
   closeAction: PropTypes.func,
   subject: PropTypes.object,
   showUnitCard: PropTypes.bool,
+  user: PropTypes.object,
 };

--- a/components/unit/unit-form-header.js
+++ b/components/unit/unit-form-header.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
-export default function UnitFormNav({ unit }) {
+
+export default function UnitFormHeader({ unit }) {
   return (
     <div className="flex space-x-6 items-center">
       <div className="rounded-full bg-yellow w-16 h-16 text-2xl font-light flex justify-center self-center">
@@ -13,6 +14,6 @@ export default function UnitFormNav({ unit }) {
   );
 }
 
-UnitFormNav.propTypes = {
+UnitFormHeader.propTypes = {
   unit: PropTypes.object.isRequired,
 };

--- a/libs/storage.js
+++ b/libs/storage.js
@@ -10,6 +10,10 @@ const storage = {
   set(key, value) {
     localStorage.setItem(key, JSON.stringify(value));
   },
+
+  remove(key) {
+    localStorage.removeItem(key);
+  },
 };
 
 export default storage;

--- a/pages/login.js
+++ b/pages/login.js
@@ -4,8 +4,11 @@ import Button from "../components/common/button";
 import { login } from "../services/auth";
 import { useRouter } from "next/router";
 import { useState, useContext } from "react";
+import { useDispatch } from "react-redux";
+import { setIsAuthenticated } from "../store/user-slicer";
 
 export default function Login() {
+  const dispatch = useDispatch();
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -29,6 +32,8 @@ export default function Login() {
         // persist token and user in localStorage
         storage.set("AUTH_TOKEN", token);
         storage.set("user", user);
+
+        dispatch(setIsAuthenticated(true));
 
         router.push("/");
       }

--- a/pages/units/[id].js
+++ b/pages/units/[id].js
@@ -1,4 +1,4 @@
-import UnitFormNav from "../../components/unit/unit-form-nav";
+import UnitFormHeader from "../../components/unit/unit-form-header";
 import UnitFormSection from "../../components/unit/unit-form-section";
 import UnitFormDates from "../../components/unit/unit-form-dates";
 import UnitFormObjectives from "../../components/unit/unit-form-objectives";
@@ -12,11 +12,12 @@ import { useEffect } from "react";
 
 export default function UnitForm() {
   const unit = useSelector((state) => state.unit);
+  const isAuthenticated = useSelector((state) => state.user.isAuthenticated);
   const dispatch = useDispatch();
   const router = useRouter();
 
   useEffect(() => {
-    if (!router.isReady) return;
+    if (!router.isReady || !isAuthenticated) return;
     const { id } = router.query;
 
     try {
@@ -37,34 +38,34 @@ export default function UnitForm() {
   };
 
   return (
-    <div className="container mx-auto xl:px-24 lg:px-0 sm:px-0 py-14">
-      {/* temporarily removing this until we decide on nav */}
-      {/* <div className="col-span-4 w-3/5 mx-auto relative">
-        {unit && <UnitFormNav unit={unit}></UnitFormNav>}
-      </div> */}
-      {/* <div className="col-span-12 mt-14"> */}
-        <div className="flex flex-col space-y-6">
-          <UnitFormSection showSaveButton={false}>
-            <UnitFormDates handleUpdate={() => handleUnitUpdate(unit.id)} />
-          </UnitFormSection>
+    <>
+      {isAuthenticated && (
+        <div className="container mx-auto xl:px-24 lg:px-0 sm:px-0 py-14">
+          <div className="flex flex-col space-y-6">
+            <UnitFormHeader unit={unit} />
 
-          <UnitFormSection tabText="Objectives">
-            <UnitFormObjectives />
-          </UnitFormSection>
+            <UnitFormSection showSaveButton={false}>
+              <UnitFormDates handleUpdate={() => handleUnitUpdate(unit.id)} />
+            </UnitFormSection>
 
-          <UnitFormSection tabText="Standards">
-            <UnitFormStandards setId={unit.setId}></UnitFormStandards>
-          </UnitFormSection>
+            <UnitFormSection tabText="Objectives">
+              <UnitFormObjectives />
+            </UnitFormSection>
 
-          <UnitFormSection tabText="Formative Assessment">
-            <UnitFormAssessment assessmentType="formative" />
-          </UnitFormSection>
+            <UnitFormSection tabText="Standards">
+              <UnitFormStandards setId={unit.setId}></UnitFormStandards>
+            </UnitFormSection>
 
-          <UnitFormSection tabText="Summative Assessment">
-            <UnitFormAssessment assessmentType="summative" />
-          </UnitFormSection>
-        {/* </div> */}
-      </div>
-    </div>
+            <UnitFormSection tabText="Formative Assessment">
+              <UnitFormAssessment assessmentType="formative" />
+            </UnitFormSection>
+
+            <UnitFormSection tabText="Summative Assessment">
+              <UnitFormAssessment assessmentType="summative" />
+            </UnitFormSection>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/services/auth.js
+++ b/services/auth.js
@@ -12,6 +12,11 @@ const login = (credentials) => {
   });
 };
 
+const logout = () => {
+  storage.remove("AUTH_TOKEN");
+  storage.remove("user");
+};
+
 const getLoggedInUser = () => {
   return storage.get("user");
 };
@@ -20,4 +25,4 @@ const isAuthenticated = () => {
   return storage.get("AUTH_TOKEN");
 };
 
-export { login, isAuthenticated, getLoggedInUser };
+export { login, logout, isAuthenticated, getLoggedInUser };

--- a/services/user.js
+++ b/services/user.js
@@ -1,4 +1,4 @@
-import { getLoggedInUser, isAuthenticated } from "./auth";
+import { getLoggedInUser } from "./auth";
 import { protectedFetcher } from "./utils";
 
 export const getSubjects = function () {

--- a/store/index.js
+++ b/store/index.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import unitReducer from "../store/unit-slicer";
+import userSlicer from "../store/user-slicer";
 
 export default configureStore({
   reducer: {
     unit: unitReducer,
+    user: userSlicer,
   },
   devTools: true,
 });

--- a/store/user-slicer.js
+++ b/store/user-slicer.js
@@ -1,0 +1,19 @@
+import { createSlice } from "@reduxjs/toolkit"
+
+export const userSlice = createSlice({
+  name: "user",
+  initialState: {
+    isAuthenticated: false,
+  },
+  reducers: {
+    setIsAuthenticated: (state, action) => {
+      state.isAuthenticated = action.payload;
+    },
+  },
+});
+
+export const {
+  setIsAuthenticated,
+} = userSlice.actions;
+
+export default userSlice.reducer;

--- a/styles/sidebar.scss
+++ b/styles/sidebar.scss
@@ -6,5 +6,6 @@ $sidebar-color: #ffffff !default;
 $icon-bg-color: $dark-blue !default;
 $submenu-bg-color: $dark-blue !default;
 $submenu-bg-color-collapsed: $dark-blue !default;
+$sidebar-width: 200px !default;
 
 @import '~react-pro-sidebar/dist/scss/styles.scss';


### PR DESCRIPTION
I'm closing out https://github.com/dgriego/teacherlab-fe/pull/13, there were issues I was seeing caused by calls to fetch from storage within the view logic.

The error I was seeing: https://github.com/vercel/next.js/discussions/17443#discussioncomment-87097

Essentially we want to avoid accessing any browser-related function outside of `useEffect`.  The solution was to check for the auth token in `useEffect` and store `isAuthenticated` in the central store so the React components can refresh and handle the state more reliably.

- Add header for unit form as well
- add fix for proficient key
- added logout functionality
- add redirects when user is not logged-in
- prevent rendering if user is not logged-in for dashboard