### PR TITLE
Adding success toast on successful save for unit

### DIFF
--- a/components/layout/wrapper.js
+++ b/components/layout/wrapper.js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { setIsAuthenticated } from "../../store/user-slicer";
+import { ToastContainer } from "react-toastify";
 import SideNav from "./sidebar";
 import Nav from "./nav";
 import Head from "next/head";
@@ -29,6 +30,13 @@ export default function Wrapper({ children }) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
+      <ToastContainer
+        className="text-center"
+        position="bottom-center"
+        autoClose={3000}
+        pauseOnHover={false}
+      />
+
       <div className="h-screen">
         <div className="flex h-full">
           {isUserAuthenticated && <SideNav />}
@@ -36,6 +44,7 @@ export default function Wrapper({ children }) {
             <div>
               <Nav />
             </div>
+
             <main className="overflow-y-auto">{children}</main>
           </div>
         </div>

--- a/components/unit/unit-form-dates.js
+++ b/components/unit/unit-form-dates.js
@@ -1,5 +1,6 @@
 import Input from "../../components/common/input";
 import Button from "../../components/common/button";
+import { toast } from "react-toastify";
 import { useSelector, useDispatch } from "react-redux";
 import { updateUnitThunk } from "../../store/unit-slicer";
 import {
@@ -8,14 +9,14 @@ import {
   setReviewDate,
 } from "../../store/unit-slicer";
 import { useState } from "react";
-import PropTypes from "prop-types";
 
-export default function UnitFormDates({ handleUpdate }) {
+export default function UnitFormDates() {
   const dispatch = useDispatch();
   const startDate = useSelector((state) => state.unit.startDate);
   const endDate = useSelector((state) => state.unit.endDate);
   const reviewDate = useSelector((state) => state.unit.reviewDate);
   const unitId = useSelector((state) => state.unit.id);
+  const unitNumber = useSelector((state) => state.unit.number);
   const [loading, setIsLoading] = useState(false);
 
   const handleUnitUpdate = async () => {
@@ -23,6 +24,7 @@ export default function UnitFormDates({ handleUpdate }) {
     try {
       await dispatch(updateUnitThunk(unitId));
       setIsLoading(false);
+      toast.success(`Unit ${unitNumber} dates have been updated!`);
     } catch (e) {
       setIsLoading(false);
       console.log(e);
@@ -66,7 +68,3 @@ export default function UnitFormDates({ handleUpdate }) {
     </div>
   );
 }
-
-UnitFormDates.propTypes = {
-  handleUpdate: PropTypes.func,
-};

--- a/components/unit/unit-form-section.js
+++ b/components/unit/unit-form-section.js
@@ -1,4 +1,5 @@
 import Button from "../../components/common/button";
+import { toast } from "react-toastify";
 import { useSelector, useDispatch } from "react-redux";
 import { updateUnitThunk } from "../../store/unit-slicer";
 import PropTypes from "prop-types";
@@ -11,6 +12,7 @@ export default function UnitFormSection({
 }) {
   const dispatch = useDispatch();
   const unitId = useSelector((state) => state.unit.id);
+  const unitNumber = useSelector((state) => state.unit.number);
   const [loading, setIsLoading] = useState(false);
 
   const handleUnitUpdate = async () => {
@@ -18,6 +20,7 @@ export default function UnitFormSection({
     try {
       await dispatch(updateUnitThunk(unitId));
       setIsLoading(false);
+      toast.success(`Unit ${unitNumber} has been updated!`);
     } catch (e) {
       console.log(e);
       setIsLoading(false);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-pro-sidebar": "^0.6.0",
     "react-redux": "^7.2.3",
     "react-select": "^4.3.0",
+    "react-toastify": "^7.0.4",
     "react-tooltip": "^4.2.17",
     "sass": "^1.32.10",
     "swr": "^0.5.4"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import "../styles/sidebar.scss";
 import "tailwindcss/tailwind.css";
+import "react-toastify/dist/ReactToastify.css";
 import UserContext from "../components/context/user-context";
 import Wrapper from "../components/layout/wrapper";
 import store from "../store/index";

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,6 +615,11 @@ classnames@^2.3.0:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.0.tgz#19524334bad47ccd99793936b67f9be0860fe835"
   integrity sha512-UUf/S3eeczXBjHPpSnrZ1ZyxH3KmLW8nVYFUWIZA/dixYMIQr7l94yYKxaAkmPk7HO9dlT6gFqAPZC02tTdfQw==
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -1868,6 +1873,13 @@ react-slidedown@^2.4.5:
   integrity sha512-zFDhgqQ1ZLfRr+rQA7p+13OTT/+zUR/+3v3JnwrnXPM8R+1KHhuTNseYHU8jYN3QfxjJXtqve0rgbWCBiFkpiw==
   dependencies:
     tslib "^1.9.0"
+
+react-toastify@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-7.0.4.tgz#7d0b743f2b96f65754264ca6eae31911a82378db"
+  integrity sha512-Rol7+Cn39hZp5hQ/k6CbMNE2CKYV9E5OQdC/hBLtIQU2xz7DdAm7xil4NITQTHR6zEbE5RVFbpgSwTD7xRGLeQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react-tooltip@^4.2.17:
   version "4.2.17"


### PR DESCRIPTION
Adding react-toastify package and simple implementation on successful save for unit.  We could add error messages with this in the future as well, but I'm sure this will do for demo purposes.

<img width="1019" alt="Screen Shot 2021-04-24 at 12 37 25 PM" src="https://user-images.githubusercontent.com/5693674/115970819-d4dd0a80-a4f9-11eb-8787-782ebaf0f75e.png">
